### PR TITLE
Add 'wk', 'wks' for weeks and 'yr', 'yrs' for years

### DIFF
--- a/src/duration.rs
+++ b/src/duration.rs
@@ -126,9 +126,9 @@ impl Parser<'_> {
             "minutes" | "minute" | "min" | "mins" | "m" => (n.mul(60)?, 0),
             "hours" | "hour" | "hr" | "hrs" | "h" => (n.mul(3600)?, 0),
             "days" | "day" | "d" => (n.mul(86400)?, 0),
-            "weeks" | "week" | "w" => (n.mul(86400 * 7)?, 0),
+            "weeks" | "week" | "wk" | "wks" | "w" => (n.mul(86400 * 7)?, 0),
             "months" | "month" | "M" => (n.mul(2_630_016)?, 0), // 30.44d
-            "years" | "year" | "y" => (n.mul(31_557_600)?, 0),  // 365.25d
+            "years" | "year" | "yr" | "yrs" | "y" => (n.mul(31_557_600)?, 0), // 365.25d
             _ => {
                 return Err(Error::UnknownUnit {
                     start,
@@ -206,11 +206,11 @@ impl Parser<'_> {
 /// * `msec`, `ms` -- milliseconds
 /// * `seconds`, `second`, `sec`, `s`
 /// * `minutes`, `minute`, `min`, `m`
-/// * `hours`, `hour`, `hr`, `h`
+/// * `hours`, `hour`, `hr`, `hrs`, `h`
 /// * `days`, `day`, `d`
-/// * `weeks`, `week`, `w`
+/// * `weeks`, `week`, `wk`, `wks`, `w`
 /// * `months`, `month`, `M` -- defined as 30.44 days
-/// * `years`, `year`, `y` -- defined as 365.25 days
+/// * `years`, `year`, `yr`, `yrs`, `y` -- defined as 365.25 days
 ///
 /// # Examples
 ///
@@ -360,6 +360,8 @@ mod test {
         assert_eq!(parse_duration("365d"), Ok(Duration::new(31_536_000, 0)));
         assert_eq!(parse_duration("1week"), Ok(Duration::new(604_800, 0)));
         assert_eq!(parse_duration("7weeks"), Ok(Duration::new(4_233_600, 0)));
+        assert_eq!(parse_duration("104wks"), Ok(Duration::new(2*31_449_600, 0)));
+        assert_eq!(parse_duration("100wk"), Ok(Duration::new(60_480_000, 0)));
         assert_eq!(parse_duration("52w"), Ok(Duration::new(31_449_600, 0)));
         assert_eq!(parse_duration("1month"), Ok(Duration::new(2_630_016, 0)));
         assert_eq!(
@@ -371,6 +373,14 @@ mod test {
         assert_eq!(
             parse_duration("7years"),
             Ok(Duration::new(7 * 31_557_600, 0))
+        );
+        assert_eq!(
+            parse_duration("15yrs"),
+            Ok(Duration::new(15*31_557_600, 0))
+        );
+        assert_eq!(
+            parse_duration("10yr"),
+            Ok(Duration::new(10*31_557_600, 0))
         );
         assert_eq!(parse_duration("17y"), Ok(Duration::new(536_479_200, 0)));
     }


### PR DESCRIPTION
Adding some (relatively less but still) commonly used short forms.

redo of #23 with rebase and unittest update 